### PR TITLE
[BREAKING] Switch to age instead of gpg

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG POSTGRES_VERSION=15
+ARG POSTGRES_VERSION=16
 FROM postgres:${POSTGRES_VERSION}-alpine
 
 RUN apk add --no-cache bash curl gpg gpg-agent rclone \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG POSTGRES_VERSION=16
 FROM postgres:${POSTGRES_VERSION}-alpine
 
-RUN apk add --no-cache bash curl gpg gpg-agent rclone \
+RUN apk add --no-cache bash curl age rclone \
   && mkdir -p /root/.config/rclone \
   && touch /root/.config/rclone/rclone.conf
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 [![Build Status](https://ci.strahlungsfrei.de/api/badges/djmaze/docker-postgres-backup/status.svg)](https://ci.strahlungsfrei.de/djmaze/docker-postgres-backup)
 [![Docker Stars](https://img.shields.io/docker/stars/decentralize/postgres-backup.svg)](https://hub.docker.com/r/decentralize/postgres-backup/) [![Docker Pulls](https://img.shields.io/docker/pulls/decentralize/postgres-backup.svg)](https://hub.docker.com/r/decentralize/postgres-backup/)
 
-This Docker image allows making a full SQL backup of a postgres database and store it GPG-encrypted on a remote location supported by rclone.
+This Docker image allows making a full SQL backup of a postgres database and store it [Age](https://github.com/FiloSottile/age)-encrypted on a remote location supported by rclone.
 
 The backup is encrypted asymmetrically, so you need to supply a public key. The holder of the private key will be able to decrypt the backup.
 
 ## Usage
+
+Create a new keypair using `age-keygen`. Store the keyfile in a secure location and run this container with the `RECIPIENT` env variable set to the public key.
 
 See [docker-compose.yml](docker-compose.yml) for an example which stores the backup using S3 on a local minio server.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,14 +7,17 @@ services:
     environment:
       - DATABASE_URL=postgres://postgres:postgres@db
       - RCLONE_CONFIG_MYS3_TYPE=s3
+      - RCLONE_S3_PROVIDER=Minio
       - RCLONE_CONFIG_MYS3_ACCESS_KEY_ID=minioadmin
       - RCLONE_CONFIG_MYS3_SECRET_ACCESS_KEY=minioadmin
       - RCLONE_CONFIG_MYS3_ENDPOINT=http://minio:9000
       - RCLONE_TARGET=mys3:backup
+
+      # secret key: AGE-SECRET-KEY-1P6TMQJ780M53NQHJ56Q47EXF504NWNGMKF6F5ZR8WKCDY5ZGQ0JSUN4SQU
+      - RECIPIENT=age17mcyt34uwq42j2s708uur4dqkt4dv3tr5jp2gmr9zpqnvc2gs3csqq0cud
+
       # optional
       # - HEALTHCHECKS_URL=https://healthchecks.example.com/ping/8382dda-5d12-475c-bd16-17a0a975e11d
-    volumes:
-      - ./example/public_key:/run/secrets/public_key:ro
     depends_on:
       - db
       - minio

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.7"
 services:
   app:
     build: .
-    image: decentralize/postgres-backup:0.1.2
+    image: decentralize/postgres-backup:0.2.0
     environment:
       - DATABASE_URL=postgres://postgres:postgres@db
       - RCLONE_CONFIG_MYS3_TYPE=s3


### PR DESCRIPTION
This is a breaking change. New backups will be encrypted with a new key. 

But I think `age` is easier to use and makes it easier to keep your sanity than `gpg`.